### PR TITLE
Feature/clangtools

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,137 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Microsoft
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      false
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 1000
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: true
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: true
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,7 @@
+Checks: '
+-*,
+performance-*,
+modernize-*,
+'
+
+HeaderFilterRegex: "(/[a-zA-Z]+)*/Game/Source/."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,25 @@ else() # UNIX
 endif(WIN32)
 
 
+set(_src_root_path "${CMAKE_SOURCE_DIR}/Game")
+# CLANG-FORMAT
+file(GLOB_RECURSE GameSrc
+  "Game/*.cpp"
+  "Game/*.h"
+  )
+
+foreach(srcFile ${GameSrc})
+
+   
+  execute_process(COMMAND "clang-format -i" "${srcFile}"
+                  COMMAND_ECHO STDOUT
+                  )
+endforeach()
+
+
 # Game files
 set(NAME "GolfGL")
-set(_src_root_path "${CMAKE_SOURCE_DIR}/Game")
+
 file(
     GLOB_RECURSE _source_list 
     LIST_DIRECTORIES false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,20 @@
 ﻿cmake_minimum_required (VERSION 3.8)
 
+
 project ("GolfGL")
+
 
 IF(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build (Debug or Release)" FORCE)
 ENDIF(NOT CMAKE_BUILD_TYPE)
 
-if (MSVC)	
-	list(APPEND CMAKE_CXX_FLAGS " /std:c++17")  	
-else()
+if (NOT MSVC)	
 	list(APPEND CMAKE_CXX_FLAGS " -std=c++17")	
-endif(MSVC)
-
+endif()
 message(STATUS ${CMAKE_CXX_FLAGS})
+
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 
 if(UNIX)
@@ -68,7 +70,6 @@ else() # UNIX
 endif(WIN32)
 
 
-
 # Game files
 set(NAME "GolfGL")
 set(_src_root_path "${CMAKE_SOURCE_DIR}/Game")
@@ -81,6 +82,7 @@ file(
     "${_src_root_path}/*.fs"
 )
 
+
 add_executable(${NAME} ${_source_list})
 foreach(_source IN ITEMS ${_source_list})
     get_filename_component(_source_path "${_source}" PATH)
@@ -92,14 +94,19 @@ endforeach()
 target_link_libraries(${NAME} ${LIBS})
 
 
-if(MSVC)
-    set_target_properties(${NAME} PROPERTIES COMPILE_FLAGS "/Ycprecomp.h /MP")
+if(MSVC)        
+    set_target_properties(${NAME} PROPERTIES COMPILE_FLAGS "/Ycprecomp.h /std:c++17")
     set_target_properties(${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/${NAME}")
-    set_target_properties(${NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/${NAME}/Debug")	
-    set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT "${NAME}")	    
+    set_target_properties(${NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/${NAME}/Debug")	    
+    set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT "${NAME}")	        
+       
+    # CLANG-TIDY
+    set_target_properties(${NAME} PROPERTIES VS_GLOBAL_RunCodeAnalysis "false")
+    set_target_properties(${NAME} PROPERTIES VS_GLOBAL_EnableClangTidyCodeAnalysis "true")
+    set_target_properties(${NAME} PROPERTIES VS_GLOBAL_ClangTidyChecks "--checks=*")
+    set_target_properties(${NAME} PROPERTIES VS_GLOBAL_EnableMicrosoftCodeAnalysis "false")
 	
 else()
-    target_precompile_headers(${NAME} PUBLIC Game/Source/precomp.h)
     set_target_properties(${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/${NAME}")
 	
 endif(MSVC)
@@ -114,12 +121,13 @@ add_custom_command(TARGET ${NAME} PRE_BUILD COMMAND
 							
 
 if(WIN32)									
-		add_custom_command(TARGET ${NAME} POST_BUILD COMMAND 
+		add_custom_command(TARGET ${NAME} PRE_LINK COMMAND 
 								${CMAKE_COMMAND} -E copy
 								"${CMAKE_SOURCE_DIR}/External/assimp/lib/assimp-vc140-mt.dll" $<TARGET_FILE_DIR:${NAME}>)	
-	
 endif(WIN32)
 
+file(GLOB_RECURSE externHeaders ${CMAKE_SOURCE_DIR}/External/*.h)
+set_source_files_properties(${externHeaders} PROPERTIES COMPILE_FLAGS "-w")
 
 include_directories(${ASSIMP_INCLUDE_DIR}
                     ${FREETYPE_INCLUDE_DIR_ft2build}
@@ -132,4 +140,6 @@ include_directories(${ASSIMP_INCLUDE_DIR}
                     ${CMAKE_SOURCE_DIR}/Game/Source
 					          ${CMAKE_SOURCE_DIR}/Game/Source/Render
                    )
-												
+
+
+				

--- a/Game/Source/Data/WindowData.h
+++ b/Game/Source/Data/WindowData.h
@@ -8,7 +8,7 @@ struct WindowData
 
 	inline static const char* glslVersion = "#version 330";
 
-	inline static std::string GetResolution() 
+	inline static auto GetResolution() -> std::string 
 	{
 		return std::to_string(width) + "x" + std::to_string(height);
 	}

--- a/Game/Source/Entities/Ball/Ball.cpp
+++ b/Game/Source/Entities/Ball/Ball.cpp
@@ -10,7 +10,7 @@ namespace Entities {
         : Render::Model("Resources/Objects/golfBall/golfBall.obj")
         , Entity("entity"), position(ballDefault::position)
         , direction(CAMERA.GetCameraFront()), m_angle(ballDefault::angle)  
-        , m_speed(0.f)
+         
     {        
         // diffuse texture is loaded in parent class    
         m_diffuseMap = (*std::find_if(textures_loaded.begin(), textures_loaded.end()

--- a/Game/Source/Entities/Ball/Ball.h
+++ b/Game/Source/Entities/Ball/Ball.h
@@ -19,7 +19,7 @@ namespace Entities {
 		glm::vec3 position;
 		glm::vec3 direction;			
 		int m_angle;
-		float m_speed;				
+		float m_speed{0.f};				
 
 		unsigned m_diffuseMap;		
 
@@ -28,7 +28,7 @@ namespace Entities {
 
 		
 
-		inline glm::vec3 m_NormalOnVec(const glm::vec3& direction)
+		inline auto m_NormalOnVec(const glm::vec3& direction) -> glm::vec3
 		{
 			return glm::normalize(glm::vec3{ direction.z, 0.f, -direction.x });
 		}

--- a/Game/Source/Entities/EntityManager.cpp
+++ b/Game/Source/Entities/EntityManager.cpp
@@ -3,7 +3,7 @@
 #include "EntityManager.h"
 
 #include "Skybox/Skybox.h"
-#include "Floor.h";
+#include "Floor.h"
 #include "Ball/Ball.h"
 
 Entities::EntityManager::~EntityManager()
@@ -11,7 +11,7 @@ Entities::EntityManager::~EntityManager()
 	m_Table.clear();
 }
 
-bool Entities::EntityManager::Init()
+auto Entities::EntityManager::Init() -> bool
 {
 	// Loading initial entities	
 	if( LoadEntity("skybox", std::make_unique<Skybox>()) 
@@ -27,7 +27,7 @@ bool Entities::EntityManager::Init()
 }
 
 // void Entities::EntityManager::LoadEntity(const std::string& name, std::unique_ptr<Entity> entity)
-bool Entities::EntityManager::LoadEntity(const std::string& name, std::unique_ptr<Entity>&& entity)
+auto Entities::EntityManager::LoadEntity(const std::string& name, std::unique_ptr<Entity>&& entity) -> bool
 {	
 	m_Table[name] = std::move( entity );
 

--- a/Game/Source/Entities/EntityManager.h
+++ b/Game/Source/Entities/EntityManager.h
@@ -11,10 +11,10 @@ namespace Entities {
 	public:
 		~EntityManager();
 
-		bool Init();
+		auto Init() -> bool;
 		
 		void Update(float delta);
-		bool LoadEntity(const std::string& name, std::unique_ptr<Entity>&& entity);
+		auto LoadEntity(const std::string& name, std::unique_ptr<Entity>&& entity) -> bool;
 
 	private:
 		std::unordered_map<std::string, std::unique_ptr<Entity>> m_Table;

--- a/Game/Source/Entities/Floor.cpp
+++ b/Game/Source/Entities/Floor.cpp
@@ -13,7 +13,7 @@ namespace Entities {
         glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
         glBufferData(GL_ARRAY_BUFFER, sizeof(planeVertices), &planeVertices, GL_STATIC_DRAW);
         glEnableVertexAttribArray(0);
-        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)0);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)nullptr);
         glEnableVertexAttribArray(1);
         glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)(3 * sizeof(float)));
         glBindVertexArray(0);

--- a/Game/Source/Entities/Floor.h
+++ b/Game/Source/Entities/Floor.h
@@ -10,7 +10,7 @@ namespace Entities {
         Floor();
         ~Floor();
 
-        void Update(float delta);        
+        void Update(float delta) override;        
 
     private:
 

--- a/Game/Source/Entities/Skybox/Skybox.cpp
+++ b/Game/Source/Entities/Skybox/Skybox.cpp
@@ -11,7 +11,7 @@ Entities::Skybox::Skybox()  :	Entity("skybox")
     glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
     glBufferData(GL_ARRAY_BUFFER, sizeof(skyData.vertices), &skyData.vertices, GL_STATIC_DRAW);
     glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)nullptr);
 
     texture = m_LoadCubemap();
     shader.ActivateShader();
@@ -41,7 +41,7 @@ void Entities::Skybox::Update(float delta)
     glDepthFunc(GL_LESS);
 }
 
-unsigned Entities::Skybox::m_LoadCubemap()
+auto Entities::Skybox::m_LoadCubemap() -> unsigned
 {
     unsigned int textureID;
     glGenTextures(1, &textureID);

--- a/Game/Source/Entities/Skybox/Skybox.h
+++ b/Game/Source/Entities/Skybox/Skybox.h
@@ -15,7 +15,7 @@ namespace Entities {
 		unsigned m_VAO, m_VBO;
 		
 
-		unsigned m_LoadCubemap();
+		auto m_LoadCubemap() -> unsigned;
 		inline void updatePV() override
 		{
 			projection = glm::perspective(glm::radians(Camera::GetCamera().GetCameraZoom())

--- a/Game/Source/Input/Input.cpp
+++ b/Game/Source/Input/Input.cpp
@@ -4,7 +4,7 @@ void mouseCallback(GLFWwindow* window, double xpos, double ypos);
 void scrollCallback(GLFWwindow* window, double xoffset, double yoffset);
 
 
-bool Input::Init(Window* window)
+auto Input::Init(Window* window) -> bool
 {
 	if (window == nullptr)
 	{
@@ -30,7 +30,7 @@ void Input::ProcessInput()
 		glfwSetWindowShouldClose(glfwWindow, true);
 
 
-	float currentFrame = (float)glfwGetTime();
+	auto currentFrame = (float)glfwGetTime();
 	deltaTime = currentFrame - lastFrame;
 	lastFrame = currentFrame;
 	Camera::GetCamera().SetCameraSpeed(deltaTime);

--- a/Game/Source/Input/Input.h
+++ b/Game/Source/Input/Input.h
@@ -7,7 +7,7 @@ class Input
 public:
 
 	Input() = default;
-	bool Init( Window* window );
+	auto Init( Window* window ) -> bool;
 	void ProcessInput();
 
 	inline static float lastX = WindowData::width / 2.0f;

--- a/Game/Source/Logger/Log.h
+++ b/Game/Source/Logger/Log.h
@@ -17,7 +17,7 @@ public:
 	void operator=(const Log&) = delete;
 		
 	static void Init();
-	inline static spdlog::logger& GetLogger() { return *ms_Logger; }	
+	inline static auto GetLogger() -> spdlog::logger& { return *ms_Logger; }	
 
 private:
 	inline static std::shared_ptr<spdlog::logger> ms_Logger;	

--- a/Game/Source/Main.cpp
+++ b/Game/Source/Main.cpp
@@ -1,5 +1,5 @@
 #include <precomp.h>
-int main()
+auto main() -> int
 {
     Log::Init();
     Render::Renderer renderer;

--- a/Game/Source/Render/Camera/Camera.cpp
+++ b/Game/Source/Render/Camera/Camera.cpp
@@ -27,7 +27,7 @@ void Camera::LookLeft()
     cameraPos -= glm::normalize(glm::cross(cameraFront, cameraUp)) * cameraSpeed;
 }
 
-glm::mat4 Camera::LookAt()
+auto Camera::LookAt() -> glm::mat4
 {
     return glm::lookAt(cameraPos, cameraPos + cameraFront, cameraUp);
 }
@@ -37,17 +37,17 @@ void Camera::SetCameraSpeed(float dt)
     cameraSpeed = MovementSpeed * dt;
 }
 
-glm::vec3 Camera::GetCameraPos()
+auto Camera::GetCameraPos() -> glm::vec3
 {
     return cameraPos;
 }
 
-float Camera::GetCameraZoom()
+auto Camera::GetCameraZoom() -> float
 {
     return Zoom;
 }
 
-glm::vec3 Camera::GetCameraFront()
+auto Camera::GetCameraFront() -> glm::vec3
 {
     return cameraFront;
 }

--- a/Game/Source/Render/Camera/Camera.h
+++ b/Game/Source/Render/Camera/Camera.h
@@ -9,19 +9,19 @@ public:
 	void operator=(const Camera&) = delete;
 	
 	static void Init();
-	inline static Camera& GetCamera() { return *ms_Camera; }
+	inline static auto GetCamera() -> Camera& { return *ms_Camera; }
 
 	void LookUp();
 	void LookDown();
 	void LookRight();
 	void LookLeft();
-    glm::mat4 LookAt();
+    auto LookAt() -> glm::mat4;
 	void SetCameraSpeed(float dt);
 
-	glm::vec3 GetCameraPos();
-	float GetCameraZoom();
+	auto GetCameraPos() -> glm::vec3;
+	auto GetCameraZoom() -> float;
 
-	glm::vec3 GetCameraFront();
+	auto GetCameraFront() -> glm::vec3;
 
 
 	void ProcessMouseMovement(float xoffset, float yoffset, GLboolean constrainPitch = GL_TRUE);

--- a/Game/Source/Render/Model/Mesh.cpp
+++ b/Game/Source/Render/Model/Mesh.cpp
@@ -4,16 +4,20 @@
 
 #include <precomp.h>
 
+
+#include <utility>
+
+
 #include "Mesh.h"
 
-Render::Mesh::Mesh(const std::vector<Render::Vertex>& _vertices, const std::vector<unsigned>& _indices,const std::vector<Render::Texture>& _textures)
-    :   vertices(_vertices), indices(_indices), textures(_textures)
+Render::Mesh::Mesh(std::vector<Render::Vertex>  _vertices, std::vector<unsigned>  _indices,std::vector<Render::Texture>  _textures)
+    :   vertices(std::move(_vertices)), indices(std::move(_indices)), textures(std::move(_textures))
 {    
     m_Init();
 }
 
-Render::Mesh::Mesh(const std::vector<Vertex>& _vertices, const std::vector<unsigned>& _indices, const Texture& _texture)
-    : vertices(_vertices), indices(_indices), textures(std::vector{ _texture })
+Render::Mesh::Mesh(std::vector<Vertex>  _vertices, std::vector<unsigned>  _indices, const Texture& _texture)
+    : vertices(std::move(_vertices)), indices(std::move(_indices)), textures(std::vector{ _texture })
 {
     m_Init();
 }
@@ -41,7 +45,7 @@ void Render::Mesh::Draw(Render::Shader* shader)
 
     // draw mesh
     glBindVertexArray(VAO);
-    glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);
+    glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, nullptr);
     glBindVertexArray(0);
 
     // always good practice to set everything back to defaults once configured.
@@ -69,7 +73,7 @@ void Render::Mesh::m_Init()
     // set the vertex attribute pointers
     // vertex Positions
     glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)nullptr);
     // vertex normals
     glEnableVertexAttribArray(1);
     glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, Normal));

--- a/Game/Source/Render/Model/Mesh.h
+++ b/Game/Source/Render/Model/Mesh.h
@@ -34,8 +34,8 @@ namespace Render {
         unsigned VAO;
 
         // constructor
-        Mesh(const std::vector<Render::Vertex>& _vertices, const std::vector<unsigned>& _indices, const std::vector<Render::Texture>& _textures);
-        Mesh(const std::vector<Render::Vertex>& _vertices, const std::vector<unsigned>& _indices, const Render::Texture&  _textures);
+        Mesh(std::vector<Render::Vertex>  _vertices, std::vector<unsigned>  _indices, std::vector<Render::Texture>  _textures);
+        Mesh(std::vector<Render::Vertex>  _vertices, std::vector<unsigned>  _indices, const Render::Texture&  _textures);
         
         // ~Mesh();
 
@@ -62,7 +62,7 @@ namespace Render {
             */
             unsigned counterArray[4]{ 0, 0, 0, 0 };
 
-            inline std::string TextureNameFactory(TextureType type)
+            inline auto TextureNameFactory(TextureType type) -> std::string
             {
                 return Texture::TypeToStringN(type, ++counterArray[(unsigned)type]);
             }

--- a/Game/Source/Render/Model/Model.cpp
+++ b/Game/Source/Render/Model/Model.cpp
@@ -8,11 +8,11 @@
 
 void Render::Model::Draw(Shader* shader)
 {
-	for (unsigned int i = 0; i < meshes.size(); i++)
-		meshes[i].Draw(shader);
+	for (auto & meshe : meshes)
+		meshe.Draw(shader);
 }
 
-void Render::Model::loadModel(std::string path)
+void Render::Model::loadModel(const std::string& path)
 {
     // read file via ASSIMP
     Assimp::Importer importer;
@@ -47,7 +47,7 @@ void Render::Model::processNode(aiNode* node, const aiScene* scene)
 }
 
 using namespace std;
-Render::Mesh Render::Model::processMesh(aiMesh* mesh, const aiScene* scene)
+auto Render::Model::processMesh(aiMesh* mesh, const aiScene* scene) -> Render::Mesh
 {
     // data to fill
     vector<Vertex> vertices;
@@ -128,8 +128,8 @@ Render::Mesh Render::Model::processMesh(aiMesh* mesh, const aiScene* scene)
     return Mesh(vertices, indices, textures);
 }
 
-std::vector<Render::Texture> Render::Model::loadMaterialTextures(aiMaterial* mat, aiTextureType type
-                                                                    , Render::TextureType typeName)
+auto Render::Model::loadMaterialTextures(aiMaterial* mat, aiTextureType type
+                                                                    , Render::TextureType typeName) -> std::vector<Render::Texture>
 {
     std::vector<Texture> textures;
     for (unsigned int i = 0; i < mat->GetTextureCount(type); i++)
@@ -138,12 +138,12 @@ std::vector<Render::Texture> Render::Model::loadMaterialTextures(aiMaterial* mat
         mat->GetTexture(type, i, &str);
         // check if texture was loaded before and if so, continue to next iteration: skip loading a new texture
         bool skip = false;
-        for (unsigned int j = 0; j < textures_loaded.size(); j++)
+        for (auto & j : textures_loaded)
         {            
             // auto textureName = textures_loaded[j].GetName().substr()
-            if (std::strcmp(textures_loaded[j].GetName().c_str(), str.C_Str()) == 0)
+            if (std::strcmp(j.GetName().c_str(), str.C_Str()) == 0)
             {
-                textures.push_back(textures_loaded[j]);
+                textures.push_back(j);
                 skip = true; // a texture with the same filepath has already been loaded, continue to next one. (optimization)
                 break;
             }

--- a/Game/Source/Render/Model/Model.h
+++ b/Game/Source/Render/Model/Model.h
@@ -17,7 +17,7 @@ namespace Render {
     class Model
     {
     public:
-        Model(std::string name)
+        Model(const std::string& name)
         {            
             loadModel(name);
         }
@@ -30,10 +30,10 @@ namespace Render {
         std::vector<Mesh> meshes;
         std::string directory;
 
-        void loadModel(std::string path);
+        void loadModel(const std::string& path);
         void processNode(aiNode* node, const aiScene* scene);
-        Mesh processMesh(aiMesh* mesh, const aiScene* scene);
-        std::vector<Texture> loadMaterialTextures(aiMaterial* mat, aiTextureType type,
-            TextureType typeName);
+        auto processMesh(aiMesh* mesh, const aiScene* scene) -> Mesh;
+        auto loadMaterialTextures(aiMaterial* mat, aiTextureType type,
+            TextureType typeName) -> std::vector<Texture>;
     };
 } // Redner

--- a/Game/Source/Render/PostProcessing/Framebuffer.cpp
+++ b/Game/Source/Render/PostProcessing/Framebuffer.cpp
@@ -16,7 +16,7 @@ namespace Render {
         glBindBuffer(GL_ARRAY_BUFFER, VBO);
         glBufferData(GL_ARRAY_BUFFER, sizeof(data.vertices), &data.vertices, GL_STATIC_DRAW);
         glEnableVertexAttribArray(0);
-        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
+        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)nullptr);
         glEnableVertexAttribArray(1);
         glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
 
@@ -30,7 +30,7 @@ namespace Render {
 
         glGenTextures(1, &textureColorBuffer);
         glBindTexture(GL_TEXTURE_2D, textureColorBuffer);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, WindowData::width, WindowData::height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, WindowData::width, WindowData::height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureColorBuffer, 0);

--- a/Game/Source/Render/Renderer.cpp
+++ b/Game/Source/Render/Renderer.cpp
@@ -6,13 +6,12 @@
 #include <Render/PostProcessing/Framebuffer.h>
 
 
-bool Render::Renderer::Init()
+auto Render::Renderer::Init() -> bool
 {
     glfwInit();
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);    
-    const char* glslVersion = "#version 330";
 
     m_Window = new Window;
     if ( !m_Window->Init() )
@@ -89,12 +88,12 @@ void Render::Renderer::Update()
     }        
 }
 
-bool Render::Renderer::IsRunning()
+auto Render::Renderer::IsRunning() -> bool
 {
     return m_Window->m_running;
 }
 
-Window* Render::Renderer::GetWindow()
+auto Render::Renderer::GetWindow() -> Window*
 {
     return m_Window;
 }

--- a/Game/Source/Render/Renderer.h
+++ b/Game/Source/Render/Renderer.h
@@ -15,11 +15,11 @@ namespace Render {
 		Renderer(Renderer&&) = delete;
 		void operator=(const Renderer&) = delete;
 
-		bool Init();
+		auto Init() -> bool;
 		void Update();
-		bool IsRunning();
+		auto IsRunning() -> bool;
 
-		Window* GetWindow();
+		auto GetWindow() -> Window*;
 
 		Renderer() = default;
 		~Renderer();

--- a/Game/Source/Render/Shader.cpp
+++ b/Game/Source/Render/Shader.cpp
@@ -127,7 +127,7 @@ inline void Render::Shader::checkCompileErrors(unsigned int shader, const char* 
 		glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
 		if (!success)
 		{
-			glGetShaderInfoLog(shader, 1024, NULL, infoLog);
+			glGetShaderInfoLog(shader, 1024, nullptr, infoLog);
 			LOG_ERROR("ERROR::SHADER_COMPILATION_ERROR of type: {} \n{} \n-- -------------------------------------------------- - -- \n", type, infoLog);
 		}
 	}
@@ -136,7 +136,7 @@ inline void Render::Shader::checkCompileErrors(unsigned int shader, const char* 
 		glGetProgramiv(shader, GL_LINK_STATUS, &success);
 		if (!success)
 		{
-			glGetProgramInfoLog(shader, 1024, NULL, infoLog);
+			glGetProgramInfoLog(shader, 1024, nullptr, infoLog);
 			LOG_ERROR("ERROR::PROGRAM_LINKING_ERROR of type: {}\n{}\n -- --------------------------------------------------- -- ", type, infoLog);
 		}
 	}

--- a/Game/Source/Render/Shader.cpp
+++ b/Game/Source/Render/Shader.cpp
@@ -118,11 +118,11 @@ void Render::Shader::setMat4(const std::string& name, const glm::mat4& mat) cons
 	glUniformMatrix4fv(glGetUniformLocation(m_ID, name.c_str()), 1, GL_FALSE, &mat[0][0]);
 }
 
-inline void Render::Shader::checkCompileErrors(unsigned int shader, const char* type) const
+inline void Render::Shader::checkCompileErrors(unsigned int shader, const std::string& type) const
 {
 	int success;
 	char infoLog[1024];
-	if (type != "PROGRAM")
+	if (type.compare("PROGRAM"))
 	{
 		glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
 		if (!success)

--- a/Game/Source/Render/Shader.h
+++ b/Game/Source/Render/Shader.h
@@ -41,7 +41,7 @@ namespace Render {
 	private:
 		unsigned m_ID;
 		
-		void checkCompileErrors(unsigned int shader, const char* type) const;
+		void checkCompileErrors(unsigned int shader, const std::string& type) const;
 
 
 		friend Renderer;

--- a/Game/Source/Render/Texture.cpp
+++ b/Game/Source/Render/Texture.cpp
@@ -4,28 +4,28 @@
 
 #include <stb_image.h>
 
-Render::Texture::Texture(std::string name, Render::TextureType type)
+Render::Texture::Texture(const std::string& name, Render::TextureType type)
 	: m_Name(name.substr( name.find_last_of('/') + 1)), m_Type(type)
 {	
 	m_ID = LoadNativeTexture(name, type);
 }
 
-unsigned Render::Texture::GetID()
+auto Render::Texture::GetID() -> unsigned
 {
 	return m_ID;
 }
 
-std::string Render::Texture::GetName()
+auto Render::Texture::GetName() -> std::string
 {
 	return m_Name;
 }
 
-Render::TextureType Render::Texture::GetType()
+auto Render::Texture::GetType() -> Render::TextureType
 {
 	return m_Type;
 }
 
-unsigned Render::Texture::LoadNativeTexture(std::string name, Render::TextureType type)
+auto Render::Texture::LoadNativeTexture(const std::string& name, Render::TextureType type) -> unsigned
 {
 	unsigned id;
 

--- a/Game/Source/Render/Texture.h
+++ b/Game/Source/Render/Texture.h
@@ -9,22 +9,22 @@ namespace Render {
 	{
 	public:	
 
-		Texture(std::string name, TextureType type = TextureType::DIFFUSE);
+		Texture(const std::string& name, TextureType type = TextureType::DIFFUSE);
 
-		unsigned GetID();
-		std::string GetName();		
-		Render::TextureType GetType();
+		auto GetID() -> unsigned;
+		auto GetName() -> std::string;		
+		auto GetType() -> Render::TextureType;
 		
-		static unsigned LoadNativeTexture(std::string name
-					, Render::TextureType type = Render::TextureType::DIFFUSE);	
+		static auto LoadNativeTexture(const std::string& name
+					, Render::TextureType type = Render::TextureType::DIFFUSE) -> unsigned;	
 
 		// string in format "texture_{type}"
-		inline static TextureType TypeFromString(const std::string& type_)
+		inline static auto TypeFromString(const std::string& type_) -> TextureType
 		{
 			return (TextureType)std::toupper(type_[8]);
 		}
 
-		inline static std::string TypeToString(TextureType type)
+		inline static auto TypeToString(TextureType type) -> std::string
 		{
 			switch (type)
 			{
@@ -47,7 +47,7 @@ namespace Render {
 		/* string in format "texture_{_type_}N" where N is 
 		*  ordinary number of texture 
 		*/
-		inline static std::string TypeToStringN(TextureType type, unsigned N)
+		inline static auto TypeToStringN(TextureType type, unsigned N) -> std::string
 		{
 			return TypeToString(type) + std::to_string(N);
 		}

--- a/Game/Source/Render/Window/Window.cpp
+++ b/Game/Source/Render/Window/Window.cpp
@@ -48,7 +48,7 @@ struct GxDataTmp
 #endif // _DEBUG
 
 
-bool Window::Init()
+auto Window::Init() -> bool
 {	
 	m_glfwWindow = glfwCreateWindow(WindowData::width, WindowData::height, WindowData::windowTitle, nullptr, nullptr);
 	if (m_glfwWindow == nullptr)
@@ -67,7 +67,7 @@ bool Window::Init()
 	return true;
 }
 
-bool Window::IsRunning()
+auto Window::IsRunning() -> bool
 {
 	return m_running;
 }
@@ -142,7 +142,7 @@ void Window::Update()
 	glfwPollEvents();
 }
 
-GLFWwindow* Window::GetGlfwWindow()
+auto Window::GetGlfwWindow() -> GLFWwindow*
 {
 	return m_glfwWindow;
 }

--- a/Game/Source/Render/Window/Window.h
+++ b/Game/Source/Render/Window/Window.h
@@ -10,11 +10,11 @@ public:
 	Window(Window&&) = delete;
 	void operator=(const Window&) = delete;
 		
-	static GLFWwindow* GetGlfwWindow();
+	static auto GetGlfwWindow() -> GLFWwindow*;
 
 
-	bool Init();
-	bool IsRunning();
+	auto Init() -> bool;
+	auto IsRunning() -> bool;
 	void Update();		
 
 	Window() = default;

--- a/Game/Source/precomp.h
+++ b/Game/Source/precomp.h
@@ -6,43 +6,43 @@
 #include "imgui_impl_opengl3.h"
 #include "misc/cpp/imgui_stdlib.h"
 #define GLFW_INCLUDE_NONE
-#include <glad.h>
 #include <GLFW/glfw3.h>
-#include <spdlog/spdlog.h>
+#include <glad.h>
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
+#include <spdlog/spdlog.h>
 #include <stb_image/stb_image.h>
 
 // Global data
 #include <Data.h>
 
 // Enums
-namespace Render {
-	enum class TextureType{
-		  DIFFUSE = 0
-		, NORMAL
-		, SPECULAR
-		, HEIGHT
-		, TEX_ERRORTYPE
-	};
+namespace Render
+{
+    enum class TextureType
+    {
+        DIFFUSE = 0,
+        NORMAL,
+        SPECULAR,
+        HEIGHT,
+        TEX_ERRORTYPE
+    };
 }
 
-
 // classes
-#include <Logger/Log.h>
 #include <Camera/Camera.h>
-#include <Window/Window.h>
 #include <Input/Input.h>
+#include <Logger/Log.h>
 #include <Render/Renderer.h>
 #include <Render/Texture.h>
-
+#include <Window/Window.h>
 
 // STL
-#include <iostream>
-#include <sstream>
-#include <fstream>
-#include <vector>
-#include <unordered_set>
-#include <memory>
 #include <exception>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <unordered_set>
+#include <vector>


### PR DESCRIPTION
It will be imporved in the future, 
clang-format will have minor changes. Clang-tidy makes problems with compilation. 
PCH don't work with clang-tidy using gcc (Unix Makefiles generator) and Visual Studio does not support
-fix flag, but everything else works well. Clang-tidy is disabled by default, because of compilation time.